### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Lint
       run: yarn lint
     - name: Build and publish docker image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: flodocks/raincheck-notify
         username: flodocks


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore